### PR TITLE
fix: specify token explicitly in inputs to bridge/consume

### DIFF
--- a/.github/workflows/splice_wf_run.yaml
+++ b/.github/workflows/splice_wf_run.yaml
@@ -30,6 +30,7 @@ jobs:
         id: bridge
         uses: leanprover-community/privilege-escalation-bridge/consume@v1
         with:
+          token: ${{ secrets.token || github.token }}
           artifact: workflow-data
           source_workflow: ${{ inputs.source_workflow }}
           expected_head_sha: ${{ inputs.expected_head_sha }}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Optional secret for `splice_wf_run.yaml`:
 
 | Name    | Required | Description                                                                      |
 | ------- | -------- | -------------------------------------------------------------------------------- |
-| `token` | Yes if you want to trigger CI       | Token used for checkout/push. Defaults to `github.token`. Prefer explicitly passing a dedicated secret (for example `SPLICE_BOT_TOKEN`) rather than `secrets: inherit`. |
+| `token` | Yes if you want to trigger CI       | Token used for artifact download, checkout, and push. Defaults to `github.token`. Prefer explicitly passing a dedicated secret (for example `SPLICE_BOT_TOKEN`) rather than `secrets: inherit`. |
 
 ***
 


### PR DESCRIPTION
should fix `GITHUB_TOKEN is required to download artifacts` error: https://github.com/leanprover-community/SpliceBot/actions/runs/21922845524