### PR TITLE
feat: change to 3-way patch apply strategy

### DIFF
--- a/.github/workflows/splice_wf_run.yaml
+++ b/.github/workflows/splice_wf_run.yaml
@@ -119,6 +119,9 @@ jobs:
             base_ref=outputs.base_ref
             base_repo=event.pull_request.base.repo.full_name
             head_repo=event.pull_request.head.repo.full_name
+            head_sha=event.pull_request.head.sha
+            head_ref=event.pull_request.head.ref
+            head_label=event.pull_request.head.label
             committer=outputs.committer
             author=outputs.author
 
@@ -138,10 +141,11 @@ jobs:
         with:
           token: ${{ secrets.token || steps.token_from_app.outputs.token || github.token }}
           repository: ${{ steps.bridge.outputs.head_repo }}
+          ref: ${{ steps.bridge.outputs.head_sha }}
           fetch-depth: 0
           path: head
 
-      - name: Create branch and copy the single file
+      - name: Stage file changes via 3-way patch apply
         if: steps.bridge.outputs.file_path != ''
         id: branch_and_copy
         run: |
@@ -150,6 +154,7 @@ jobs:
           FILE_PATH="${{ steps.bridge.outputs.file_path }}"
           PR_NUMBER="${{ steps.bridge.outputs.pr_number }}"
           BASE_REF="${{ steps.bridge.outputs.base_ref }}"
+          HEAD_SHA="${{ steps.bridge.outputs.head_sha }}"
 
           # Only keep alphanumeric characters from file name
           SAFE_FILE="$(echo "$FILE_PATH" | sed 's/[^0-9a-zA-Z/._]*//g' | tr -d '\n')"
@@ -160,16 +165,34 @@ jobs:
 
           cd base
 
-          # Ensure directory exists for the target file
-          mkdir -p "$(dirname "$FILE_PATH")"
+          git checkout "${BASE_REF}"
 
-          # Copy or delete the file to match HEAD state
-          if [ -f "../head/${FILE_PATH}" ]; then
-            echo "Copying file from PR head: ${FILE_PATH}"
-            cp -f "../head/${FILE_PATH}" "${FILE_PATH}"
-            git add "${FILE_PATH}"
-          else
-            echo "File not present at PR head path: ${FILE_PATH}"
+          # Import the PR head commit into this repo object graph so merge-base/diff can run reliably.
+          git remote remove splice_head >/dev/null 2>&1 || true
+          git remote add splice_head ../head
+          git fetch --no-tags splice_head "${HEAD_SHA}"
+
+          HEAD_COMMIT="$(git rev-parse FETCH_HEAD)"
+          MERGE_BASE="$(git merge-base "${BASE_REF}" "${HEAD_COMMIT}" || true)"
+          if [ -z "${MERGE_BASE}" ]; then
+            echo "No merge-base found between ${BASE_REF} and ${HEAD_COMMIT}; cannot build patch."
+            echo "APPLY_FAILED=true" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PATCH_FILE="../splice-file.patch"
+          git diff --binary --no-color "${MERGE_BASE}" "${HEAD_COMMIT}" -- "${FILE_PATH}" > "${PATCH_FILE}"
+
+          if [ ! -s "${PATCH_FILE}" ]; then
+            echo "No patch content for ${FILE_PATH} from ${MERGE_BASE}..${HEAD_COMMIT}"
+            echo "NO_CHANGES=true" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git apply --3way --index "${PATCH_FILE}"; then
+            echo "Patch apply failed for ${FILE_PATH}"
+            echo "APPLY_FAILED=true" | tee -a "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           if git diff --cached --quiet; then
@@ -179,7 +202,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        if: steps.bridge.outputs.file_path != '' && steps.branch_and_copy.outputs.NO_CHANGES != 'true'
+        if: steps.bridge.outputs.file_path != '' && steps.branch_and_copy.outputs.NO_CHANGES != 'true' && steps.branch_and_copy.outputs.APPLY_FAILED != 'true'
         id: cpr
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 #v8.0.0
         with:
@@ -208,8 +231,14 @@ jobs:
             const originalPrNumber = Number('${{ steps.bridge.outputs.pr_number }}');
             const repoFull = '${{ steps.bridge.outputs.base_repo }}';
             const [owner, repo] = repoFull.split('/');
-            const automatedPrNumber = '${{ steps.cpr.outputs.pull-request-number }}';
             const filePath = '${{ steps.bridge.outputs.file_path }}';
-
-            const body = `Split off the changes to **${filePath}** in #${automatedPrNumber}`;
+            const applyFailed = '${{ steps.branch_and_copy.outputs.APPLY_FAILED }}' === 'true';
+            const automatedPrNumber = '${{ steps.cpr.outputs.pull-request-number }}';
+            const baseRef = '${{ steps.bridge.outputs.base_ref }}';
+            const headRef = '${{ steps.bridge.outputs.head_ref }}';
+            const headLabel = '${{ steps.bridge.outputs.head_label }}';
+            const sourceBranch = headLabel || headRef;
+            const body = applyFailed
+              ? `I couldn't cleanly apply the changes for **${filePath}** onto the latest base branch (**${baseRef}**). Please either rebase, or merge **${baseRef}** into source branch **${sourceBranch}**, then try again.`
+              : `Split off the changes to **${filePath}** in #${automatedPrNumber}`;
             await github.rest.issues.createComment({ owner, repo, issue_number: originalPrNumber, body });

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Token caveats:
 
 * If `token` is `github.token`, downstream workflows may not trigger on the bot-created push/PR.
 * If using `push_to_fork`, the branch push token (resolved from `branch_token` then `token`) must have write access to that fork.
+* If the selected file is under `.github/workflows/`, the token that pushes the branch must have `Workflows: Read & write` (GitHub rejects workflow-file updates from apps without this permission).
 * `maintainer_can_modify` is a GitHub platform capability that is commonly used with user-owned forks; set it explicitly if your repository policy requires it.
 * GitHub does not allow granting push permissions to organization-owned forks, so maintainer-edit behavior differs from user-owned forks ([GitHub docs](https://docs.github.com/pull-requests/collaborating-with-pull-requests/working-with-forks/about-permissions-and-visibility-of-forks)).
 * For additional behavior details and fork setup patterns, see the upstream action guidance ([peter-evans/create-pull-request: Push pull request branches to a fork](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork)).


### PR DESCRIPTION
This will prevent changes in the target branch from being overwritten, and also keep workflow changes in the target branch from requiring more permissions in the `branch_token`.